### PR TITLE
Seperate the build and release workflow in github actions 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,117 @@
+name: Build (Test Only)
+
+on:
+  push:
+    branches:
+      - "break-and-build"
+  pull_request:
+    branches:
+      - main
+
+env:
+  APP_NAME: securebank
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux
+            executable: crow_bank_app
+            archive_format: tar.gz
+          - platform: windows
+            executable: crow_bank_app.exe
+            archive_format: zip
+    defaults:
+      run:
+        working-directory: crow-bank-app
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            /usr/include/boost
+            /usr/lib/x86_64-linux-gnu/libboost*
+          key: ubuntu-boost-${{ hashFiles('**/CMakeLists.txt') }}
+          restore-keys: |
+            ubuntu-boost-
+
+      - name: Set up dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake g++ make zip
+          sudo apt-get install -y mingw-w64
+          sudo apt-get install -y libboost-all-dev
+          sudo apt-get install -y libboost-all-dev:amd64
+          wget -q https://github.com/microsoft/vcpkg/archive/refs/heads/master.zip
+          unzip -q master.zip
+          cd vcpkg-master
+          ./bootstrap-vcpkg.sh
+          ./vcpkg install boost-algorithm:x64-mingw-static boost-system:x64-mingw-static
+          cd ..
+          sudo apt-get install -y libboost-dev-mingw-w64 || echo "MinGW Boost not available, using alternative approach"
+          echo "Checking Boost installation:"
+          ls -la /usr/include/boost/ | head -5
+          echo "Boost algorithm headers:"
+          ls -la /usr/include/boost/algorithm/ | head -5
+          echo "MinGW compiler location:"
+          which x86_64-w64-mingw32-g++
+          echo "MinGW include paths:"
+          x86_64-w64-mingw32-g++ -v -E -x c++ - < /dev/null 2>&1 | grep -A 20 "search starts here"
+
+      - name: Prepare Boost headers for MinGW (Windows only)
+        if: matrix.platform == 'windows'
+        run: |
+          BOOST_SRC=/usr/include/boost
+          MINGW_INCLUDE=/usr/x86_64-w64-mingw32/include/boost
+          if [ ! -d "$MINGW_INCLUDE" ]; then
+            sudo mkdir -p /usr/x86_64-w64-mingw32/include
+            sudo cp -r $BOOST_SRC /usr/x86_64-w64-mingw32/include/
+          fi
+
+      - name: Configure and Build
+        run: |
+          if [ "${{ matrix.platform }}" == "linux" ]; then
+            echo "🐧 Building for Linux..."
+            mkdir -p build-linux
+            cd build-linux
+            cmake .. -DCMAKE_BUILD_TYPE=Release
+            make -j$(nproc)
+            cp crow_bank_app ../crow_bank_app
+          else
+            echo "🪟 Building for Windows (cross-compilation)..."
+            mkdir -p win-build
+            cd win-build
+            cmake .. -DCMAKE_TOOLCHAIN_FILE=../win-toolchain.cmake -DCMAKE_BUILD_TYPE=Release
+            make -j$(nproc)
+            cp crow_bank_app.exe ../crow_bank_app.exe
+          fi
+
+      - name: Verify build output
+        run: |
+          ls -la
+          if [ ! -f "${{ matrix.executable }}" ]; then
+            echo "Error: Expected executable ${{ matrix.executable }} not found"
+            exit 1
+          fi
+
+      - name: Prepare test artifact
+        run: |
+          PACKAGE_DIR="${{ env.APP_NAME }}-${{ matrix.platform }}"
+          mkdir -p "$PACKAGE_DIR"
+          cp -r public "$PACKAGE_DIR/public"
+          cp README.md "$PACKAGE_DIR/README.txt" || echo "No README.md found"
+          cp ${{ matrix.executable }} "$PACKAGE_DIR/"
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.APP_NAME }}-${{ matrix.platform }}
+          path: crow-bank-app/${{ env.APP_NAME }}-${{ matrix.platform }}/*
+          retention-days: 7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,6 @@
 name: Build (Test Only)
 
 on:
-  push:
-    branches:
-      - "break-and-build"
   pull_request:
     branches:
       - main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,8 @@
 name: Build and Release
-# Comment for testing
+
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
-  release:
-    types: [published]
 
 env:
   APP_NAME: securebank
@@ -117,26 +113,27 @@ jobs:
 
       - name: Prepare release package
         run: |
-          mkdir -p out
-          cp -r public out/public
-          cp README.md out/README.txt || echo "No README.md found"
-          cp ${{ matrix.executable }} out/
+          PACKAGE_DIR="${{ env.APP_NAME }}-${{ matrix.platform }}"
+          mkdir -p "$PACKAGE_DIR"
+          cp -r public "$PACKAGE_DIR/public"
+          cp README.md "$PACKAGE_DIR/README.txt" || echo "No README.md found"
+          cp ${{ matrix.executable }} "$PACKAGE_DIR/"
 
           # Create version info
-          echo "SecureBank C++ Banking Application" > out/README.txt
-          echo "Version: $(date +%Y.%m.%d-%H%M%S)" >> out/README.txt
-          echo "Platform: ${{ matrix.platform }}" >> out/README.txt
-          echo "Built on: $(date)" >> out/README.txt
-          echo "" >> out/README.txt
-          echo "Usage:" >> out/README.txt
-          echo "1. Run the executable: ./${{ matrix.executable }}" >> out/README.txt
-          echo "2. Open browser to http://localhost:8080" >> out/README.txt
+          echo "SecureBank C++ Banking Application" > "$PACKAGE_DIR/README.txt"
+          echo "Version: $(date +%Y.%m.%d-%H%M%S)" >> "$PACKAGE_DIR/README.txt"
+          echo "Platform: ${{ matrix.platform }}" >> "$PACKAGE_DIR/README.txt"
+          echo "Built on: $(date)" >> "$PACKAGE_DIR/README.txt"
+          echo "" >> "$PACKAGE_DIR/README.txt"
+          echo "Usage:" >> "$PACKAGE_DIR/README.txt"
+          echo "1. Run the executable: ./${{ matrix.executable }}" >> "$PACKAGE_DIR/README.txt"
+          echo "2. Open browser to http://localhost:8080" >> "$PACKAGE_DIR/README.txt"
 
           # Create archive based on platform
           if [ "${{ matrix.platform }}" == "windows" ]; then
-            zip -r ${{ env.APP_NAME }}-${{ matrix.platform }}.zip out/*
+            zip -r "$PACKAGE_DIR.zip" "$PACKAGE_DIR"
           else
-            tar -czf ${{ env.APP_NAME }}-${{ matrix.platform }}.tar.gz -C out .
+            tar -czf "$PACKAGE_DIR.tar.gz" "$PACKAGE_DIR"
           fi
 
       - name: Upload build artifacts
@@ -147,7 +144,6 @@ jobs:
           retention-days: 30
 
   create-release:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: build
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for testing builds (`build.yml`) and updates the existing release workflow (`release.yml`) to align with the new build process and improve artifact preparation. Below are the key changes:

### New Build Workflow (`.github/workflows/build.yml`):

* **Introduction of a Test-Only Build Workflow**: A new workflow named "Build (Test Only)" was added to run on `push` events to the `break-and-build` branch and `pull_request` events targeting `main`. It supports both Linux and Windows builds with a matrix strategy.
* **Dependency Setup and Caching**: Added steps to install dependencies like Boost, configure MinGW for cross-compilation, and cache Boost libraries for faster builds.
* **Build and Verification Process**: Includes platform-specific build steps, cross-compilation for Windows, and verification of the build output.
* **Artifact Packaging and Upload**: Packages build artifacts into platform-specific directories and uploads them with a 7-day retention period.

### Updates to Release Workflow (`.github/workflows/release.yml`):

* **Trigger Simplification**: Removed `pull_request` and `release` triggers to focus solely on `push` events to `main`.
* **Artifact Packaging Alignment**: Updated the artifact preparation logic to match the new structure introduced in the build workflow, including platform-specific directories and improved README generation.
* **Archive Creation Improvement**: Adjusted archive creation to use the new directory structure, ensuring consistency between platforms.
* **Conditional Release Step**: Removed the conditional check for triggering the `create-release` job, simplifying the workflow logic.